### PR TITLE
feat: implement theme changing feature to sync with parent app

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -30,9 +30,9 @@ const App = () => {
   const appStore = useSelector(state => state.app);
   const [translationTokens, setTranslationTokens] = useState();
 
-  function notifyParentWhenAppLoaded() {
+  const notifyParentWhenAppLoaded = () => {
     window.parent.postMessage('appLoaded', window.location.origin);
-  }
+  };
 
   useEffect(() => {
     const handleMessage = event => {

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux';
 
 import {
   getUser,
+  setCustomTheme,
   setLocale,
   setThemeFromLocalStorage,
 } from './store/actions/app';
@@ -16,7 +17,6 @@ import { initiateSocket } from './store/actions/socket';
 
 import { loadLocaleData } from './translations';
 import { AppNavigator } from './navigation';
-import theme from './theme';
 
 import {
   IndeterminateProgressOverlay,
@@ -29,6 +29,25 @@ const App = () => {
   const { socketStatus } = useSelector(state => state.app);
   const appStore = useSelector(state => state.app);
   const [translationTokens, setTranslationTokens] = useState();
+
+  function notifyParentWhenAppLoaded() {
+    window.parent.postMessage('appLoaded', window.location.origin);
+  }
+
+  useEffect(() => {
+    const handleMessage = event => {
+      if (event.data.customThemeColors) {
+        dispatch(setCustomTheme(event.data.customThemeColors));
+      }
+    };
+    notifyParentWhenAppLoaded();
+
+    window.addEventListener('message', handleMessage);
+
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, []);
 
   useEffect(() => {
     dispatch(initiateSocket(appStore.serverAddress));
@@ -58,7 +77,7 @@ const App = () => {
   }
 
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={appStore.customTheme}>
       <IntlProvider
         locale="en"
         defaultLocale="en"

--- a/src/components/blocks/LeftNav.js
+++ b/src/components/blocks/LeftNav.js
@@ -33,27 +33,23 @@ const NavContainer = styled('div')`
   width: 16rem;
   min-width: 16rem;
   height: 100%;
-  background-color: ${props =>
-    props.theme.customColors?.leftNavBgColor ??
-    props.theme.colors.default.shade1};
+  background-color: ${props => props.theme.colors.default.leftNav.bg};
 `;
 
 const MenuItem = styled(Link)`
   background: ${props =>
     props.selected
-      ? props.theme.customColors?.leftNavHighlightColor ?? 'white'
+      ? props.theme.colors.default.leftNav.highlight
       : 'transparent'};
   :hover {
     background: ${props => props.theme.colors.default.primary};
   }
   padding: 0.5625rem 0rem 0.75rem 3.25rem;
   text-transform: uppercase;
-  ${props =>
-    props.theme.customColors?.leftNavTextColor
-      ? `color: ${props.theme.customColors?.leftNavTextColor};`
-      : props.selected
-      ? `color: ${props.theme.colors.default.primary};`
-      : 'color: #6e7d7f;'}
+  color: ${props =>
+    props.selected
+      ? props.theme.colors.default.primary
+      : props.theme.colors.default.leftNav.text};
   font-family: ${props => props.theme.typography.primary.bold};
   cursor: pointer;
   display: block;
@@ -119,17 +115,9 @@ const LeftNav = withTheme(({ children, theme }) => {
           <WarehouseIcon
             height={24}
             width={24}
-            color={
-              theme.customColors?.leftNavTextColor ??
-              theme.colors.default.primary
-            }
+            color={theme.colors.default.leftNav.text}
           />
-          <ButtonText
-            color={
-              theme.customColors?.leftNavTextColor ??
-              theme.colors.default.primary
-            }
-          >
+          <ButtonText color={theme.colors.default.leftNav.text}>
             <FormattedMessage id="cadt" />
           </ButtonText>
         </StyledTitleContainer>
@@ -154,28 +142,17 @@ const LeftNav = withTheme(({ children, theme }) => {
                 <CircularProgress
                   size={20}
                   thickness={5}
-                  color={
-                    theme.customColors?.leftNavTextColor ??
-                    theme.colors.default.primary
-                  }
+                  color={theme.colors.default.leftNav.text}
                 />
               )}
               {!isMyOrgPending && (
                 <RegistryIcon
                   height={20}
                   width={20}
-                  color={
-                    theme.customColors?.leftNavTextColor ??
-                    theme.colors.default.primary
-                  }
+                  color={theme.colors.default.leftNav.text}
                 />
               )}
-              <ButtonText
-                color={
-                  theme.customColors?.leftNavTextColor ??
-                  theme.colors.default.primary
-                }
-              >
+              <ButtonText color={theme.colors.default.leftNav.text}>
                 <FormattedMessage id="my-registry" />
               </ButtonText>
             </StyledTitleContainer>

--- a/src/components/blocks/LeftNav.js
+++ b/src/components/blocks/LeftNav.js
@@ -33,20 +33,19 @@ const NavContainer = styled('div')`
   width: 16rem;
   min-width: 16rem;
   height: 100%;
-  background-color: ${props => props.theme.colors.default.shade1};
+  background-color: ${props =>
+    props.color ?? props.theme.colors.default.shade1};
 `;
 
 const MenuItem = styled(Link)`
-  background: ${props => (props.selected ? 'white' : 'transparent')};
+  background: ${props =>
+    props.selected ? props.highlightColor ?? 'white' : 'transparent'};
   :hover {
     background: ${props => props.theme.colors.default.primary};
   }
   padding: 0.5625rem 0rem 0.75rem 3.25rem;
   text-transform: uppercase;
-  ${props =>
-    props.selected
-      ? `color: ${props.theme.colors.default.primary};`
-      : 'color: #6e7d7f;'}
+  ${props => `color: ${props.color ?? props.theme.colors.default.primary};`}
   font-family: ${props => props.theme.typography.primary.bold};
   cursor: pointer;
   display: block;
@@ -80,6 +79,30 @@ const LeftNav = withTheme(({ children, theme }) => {
   const { isGovernance } = useSelector(state => state.climateWarehouse);
   const dispatch = useDispatch();
   const [myOrgUid, isMyOrgPending] = useSelector(store => getHomeOrg(store));
+  const [colors, setColors] = useState({
+    topBarBgColor: undefined,
+    leftNavHighlightColor: undefined,
+    leftNavBgColor: undefined,
+    leftNavTextColor: undefined,
+  });
+  function notifyParentWhenLeftNavLoaded() {
+    window.parent.postMessage('leftNavLoaded', window.location.origin);
+  }
+
+  useEffect(() => {
+    const handleMessage = event => {
+      if (event.data.colors) {
+        setColors(event.data.colors);
+      }
+    };
+    notifyParentWhenLeftNavLoaded();
+
+    window.addEventListener('message', handleMessage);
+
+    return () => {
+      window.removeEventListener('message', handleMessage);
+    };
+  }, []);
 
   const isMyOrgCreated = !!myOrgUid;
 
@@ -107,38 +130,84 @@ const LeftNav = withTheme(({ children, theme }) => {
 
   return (
     <Container>
-      <NavContainer>
+      <NavContainer color={colors.leftNavBgColor}>
         <StyledTitleContainer>
-          <WarehouseIcon height={24} width={24} color="#6e7d7f" />
-          <ButtonText color={theme.colors.default.primary}>
+          <WarehouseIcon
+            height={24}
+            width={24}
+            color={colors.leftNavTextColor ?? theme.colors.default.primary}
+          />
+          <ButtonText
+            color={colors.leftNavTextColor ?? theme.colors.default.primary}
+          >
             <FormattedMessage id="cadt" />
           </ButtonText>
         </StyledTitleContainer>
-        <MenuItem selected={isProjectsPage && !isMyRegistryPage} to="/projects">
+        <MenuItem
+          color={colors.leftNavTextColor}
+          highlightColor={colors.leftNavHighlightColor}
+          selected={isProjectsPage && !isMyRegistryPage}
+          to="/projects"
+        >
           <FormattedMessage id="projects-list" />
         </MenuItem>
         <div></div>
-        <MenuItem selected={isUnitsPage && !isMyRegistryPage} to="/units">
+        <MenuItem
+          color={colors.leftNavTextColor}
+          highlightColor={colors.leftNavHighlightColor}
+          selected={isUnitsPage && !isMyRegistryPage}
+          to="/units"
+        >
           <FormattedMessage id="units-list" />
         </MenuItem>
-        <MenuItem selected={isAuditPage} to="/audit">
+        <MenuItem
+          color={colors.leftNavTextColor}
+          highlightColor={colors.leftNavHighlightColor}
+          selected={isAuditPage}
+          to="/audit"
+        >
           <FormattedMessage id="audit" />
         </MenuItem>
-        <MenuItem selected={isGlossaryPage} to={`/glossary`}>
+        <MenuItem
+          color={colors.leftNavTextColor}
+          highlightColor={colors.leftNavHighlightColor}
+          selected={isGlossaryPage}
+          to={`/glossary`}
+        >
           <FormattedMessage id="glossary" />
         </MenuItem>
 
         {!readOnlyMode && (
           <>
             <StyledTitleContainer disabled={!isMyOrgCreated || isMyOrgPending}>
-              {isMyOrgPending && <CircularProgress size={20} thickness={5} />}
-              {!isMyOrgPending && <RegistryIcon height={20} width={20} />}
-              <ButtonText color={theme.colors.default.primary}>
+              {isMyOrgPending && (
+                <CircularProgress
+                  size={20}
+                  thickness={5}
+                  color={
+                    colors.leftNavTextColor ?? theme.colors.default.primary
+                  }
+                />
+              )}
+              {!isMyOrgPending && (
+                <RegistryIcon
+                  height={20}
+                  width={20}
+                  color={
+                    colors.leftNavTextColor ?? theme.colors.default.primary
+                  }
+                />
+              )}
+              <ButtonText
+                color={colors.leftNavTextColor ?? theme.colors.default.primary}
+              >
                 <FormattedMessage id="my-registry" />
               </ButtonText>
             </StyledTitleContainer>
             {!isMyOrgCreated && (
               <MenuItem
+                color={colors.leftNavTextColor}
+                highlightColor={colors.leftNavHighlightColor}
                 to={projectsPageUrl}
                 onClick={() => setCreateOrgIsVisible(true)}
               >
@@ -146,13 +215,20 @@ const LeftNav = withTheme(({ children, theme }) => {
               </MenuItem>
             )}
             {isMyOrgPending && (
-              <MenuItem to={projectsPageUrl} disabled>
+              <MenuItem
+                to={projectsPageUrl}
+                color={colors.leftNavTextColor}
+                highlightColor={colors.leftNavHighlightColor}
+                disabled
+              >
                 <FormattedMessage id="creating-organization" />
               </MenuItem>
             )}
             {isMyOrgCreated && !isMyOrgPending ? (
               <>
                 <MenuItem
+                  color={colors.leftNavTextColor}
+                  highlightColor={colors.leftNavHighlightColor}
                   selected={isProjectsPage && isMyRegistryPage}
                   to={`/projects?orgUid=${myOrgUid}&myRegistry=true`}
                 >
@@ -161,21 +237,38 @@ const LeftNav = withTheme(({ children, theme }) => {
                 <div></div>
                 <MenuItem
                   selected={isUnitsPage && isMyRegistryPage}
+                  color={colors.leftNavTextColor}
+                  highlightColor={colors.leftNavHighlightColor}
                   to={`/units?orgUid=${myOrgUid}&myRegistry=true`}
                 >
                   <FormattedMessage id="my-units" />
                 </MenuItem>
 
                 <div></div>
-                <MenuItem selected={isFilesPage} to={`/files`}>
+                <MenuItem
+                  selected={isFilesPage}
+                  color={colors.leftNavTextColor}
+                  highlightColor={colors.leftNavHighlightColor}
+                  to={`/files`}
+                >
                   <FormattedMessage id="my-files" />
                 </MenuItem>
 
-                <MenuItem selected={isOrganizationPage} to="/organization">
+                <MenuItem
+                  selected={isOrganizationPage}
+                  color={colors.leftNavTextColor}
+                  highlightColor={colors.leftNavHighlightColor}
+                  to="/organization"
+                >
                   <FormattedMessage id="my-organization" />
                 </MenuItem>
                 {isGovernance && (
-                  <MenuItem selected={isGovernancePage} to="/governance">
+                  <MenuItem
+                    selected={isGovernancePage}
+                    color={colors.leftNavTextColor}
+                    highlightColor={colors.leftNavHighlightColor}
+                    to="/governance"
+                  >
                     <FormattedMessage id="governance" />
                   </MenuItem>
                 )}
@@ -184,6 +277,8 @@ const LeftNav = withTheme(({ children, theme }) => {
               <>
                 <MenuItem
                   to={projectsPageUrl}
+                  style={{ color: colors.leftNavTextColor }}
+                  highlightColor={colors.leftNavHighlightColor}
                   onClick={() => setConfirmCreateOrgIsVisible(true)}
                   disabled
                 >
@@ -192,6 +287,8 @@ const LeftNav = withTheme(({ children, theme }) => {
                 <div></div>
                 <MenuItem
                   to={projectsPageUrl}
+                  color={colors.leftNavTextColor}
+                  highlightColor={colors.leftNavHighlightColor}
                   onClick={() => setConfirmCreateOrgIsVisible(true)}
                   disabled
                 >

--- a/src/components/blocks/LeftNav.js
+++ b/src/components/blocks/LeftNav.js
@@ -34,18 +34,26 @@ const NavContainer = styled('div')`
   min-width: 16rem;
   height: 100%;
   background-color: ${props =>
-    props.color ?? props.theme.colors.default.shade1};
+    props.theme.customColors?.leftNavBgColor ??
+    props.theme.colors.default.shade1};
 `;
 
 const MenuItem = styled(Link)`
   background: ${props =>
-    props.selected ? props.highlightColor ?? 'white' : 'transparent'};
+    props.selected
+      ? props.theme.customColors?.leftNavHighlightColor ?? 'white'
+      : 'transparent'};
   :hover {
     background: ${props => props.theme.colors.default.primary};
   }
   padding: 0.5625rem 0rem 0.75rem 3.25rem;
   text-transform: uppercase;
-  ${props => `color: ${props.color ?? props.theme.colors.default.primary};`}
+  ${props =>
+    props.theme.customColors?.leftNavTextColor
+      ? `color: ${props.theme.customColors?.leftNavTextColor};`
+      : props.selected
+      ? `color: ${props.theme.colors.default.primary};`
+      : 'color: #6e7d7f;'}
   font-family: ${props => props.theme.typography.primary.bold};
   cursor: pointer;
   display: block;
@@ -79,30 +87,6 @@ const LeftNav = withTheme(({ children, theme }) => {
   const { isGovernance } = useSelector(state => state.climateWarehouse);
   const dispatch = useDispatch();
   const [myOrgUid, isMyOrgPending] = useSelector(store => getHomeOrg(store));
-  const [colors, setColors] = useState({
-    topBarBgColor: undefined,
-    leftNavHighlightColor: undefined,
-    leftNavBgColor: undefined,
-    leftNavTextColor: undefined,
-  });
-  function notifyParentWhenLeftNavLoaded() {
-    window.parent.postMessage('leftNavLoaded', window.location.origin);
-  }
-
-  useEffect(() => {
-    const handleMessage = event => {
-      if (event.data.colors) {
-        setColors(event.data.colors);
-      }
-    };
-    notifyParentWhenLeftNavLoaded();
-
-    window.addEventListener('message', handleMessage);
-
-    return () => {
-      window.removeEventListener('message', handleMessage);
-    };
-  }, []);
 
   const isMyOrgCreated = !!myOrgUid;
 
@@ -130,50 +114,36 @@ const LeftNav = withTheme(({ children, theme }) => {
 
   return (
     <Container>
-      <NavContainer color={colors.leftNavBgColor}>
+      <NavContainer>
         <StyledTitleContainer>
           <WarehouseIcon
             height={24}
             width={24}
-            color={colors.leftNavTextColor ?? theme.colors.default.primary}
+            color={
+              theme.customColors?.leftNavTextColor ??
+              theme.colors.default.primary
+            }
           />
           <ButtonText
-            color={colors.leftNavTextColor ?? theme.colors.default.primary}
+            color={
+              theme.customColors?.leftNavTextColor ??
+              theme.colors.default.primary
+            }
           >
             <FormattedMessage id="cadt" />
           </ButtonText>
         </StyledTitleContainer>
-        <MenuItem
-          color={colors.leftNavTextColor}
-          highlightColor={colors.leftNavHighlightColor}
-          selected={isProjectsPage && !isMyRegistryPage}
-          to="/projects"
-        >
+        <MenuItem selected={isProjectsPage && !isMyRegistryPage} to="/projects">
           <FormattedMessage id="projects-list" />
         </MenuItem>
         <div></div>
-        <MenuItem
-          color={colors.leftNavTextColor}
-          highlightColor={colors.leftNavHighlightColor}
-          selected={isUnitsPage && !isMyRegistryPage}
-          to="/units"
-        >
+        <MenuItem selected={isUnitsPage && !isMyRegistryPage} to="/units">
           <FormattedMessage id="units-list" />
         </MenuItem>
-        <MenuItem
-          color={colors.leftNavTextColor}
-          highlightColor={colors.leftNavHighlightColor}
-          selected={isAuditPage}
-          to="/audit"
-        >
+        <MenuItem selected={isAuditPage} to="/audit">
           <FormattedMessage id="audit" />
         </MenuItem>
-        <MenuItem
-          color={colors.leftNavTextColor}
-          highlightColor={colors.leftNavHighlightColor}
-          selected={isGlossaryPage}
-          to={`/glossary`}
-        >
+        <MenuItem selected={isGlossaryPage} to={`/glossary`}>
           <FormattedMessage id="glossary" />
         </MenuItem>
 
@@ -185,7 +155,8 @@ const LeftNav = withTheme(({ children, theme }) => {
                   size={20}
                   thickness={5}
                   color={
-                    colors.leftNavTextColor ?? theme.colors.default.primary
+                    theme.customColors?.leftNavTextColor ??
+                    theme.colors.default.primary
                   }
                 />
               )}
@@ -194,20 +165,22 @@ const LeftNav = withTheme(({ children, theme }) => {
                   height={20}
                   width={20}
                   color={
-                    colors.leftNavTextColor ?? theme.colors.default.primary
+                    theme.customColors?.leftNavTextColor ??
+                    theme.colors.default.primary
                   }
                 />
               )}
               <ButtonText
-                color={colors.leftNavTextColor ?? theme.colors.default.primary}
+                color={
+                  theme.customColors?.leftNavTextColor ??
+                  theme.colors.default.primary
+                }
               >
                 <FormattedMessage id="my-registry" />
               </ButtonText>
             </StyledTitleContainer>
             {!isMyOrgCreated && (
               <MenuItem
-                color={colors.leftNavTextColor}
-                highlightColor={colors.leftNavHighlightColor}
                 to={projectsPageUrl}
                 onClick={() => setCreateOrgIsVisible(true)}
               >
@@ -215,20 +188,13 @@ const LeftNav = withTheme(({ children, theme }) => {
               </MenuItem>
             )}
             {isMyOrgPending && (
-              <MenuItem
-                to={projectsPageUrl}
-                color={colors.leftNavTextColor}
-                highlightColor={colors.leftNavHighlightColor}
-                disabled
-              >
+              <MenuItem to={projectsPageUrl} disabled>
                 <FormattedMessage id="creating-organization" />
               </MenuItem>
             )}
             {isMyOrgCreated && !isMyOrgPending ? (
               <>
                 <MenuItem
-                  color={colors.leftNavTextColor}
-                  highlightColor={colors.leftNavHighlightColor}
                   selected={isProjectsPage && isMyRegistryPage}
                   to={`/projects?orgUid=${myOrgUid}&myRegistry=true`}
                 >
@@ -237,38 +203,21 @@ const LeftNav = withTheme(({ children, theme }) => {
                 <div></div>
                 <MenuItem
                   selected={isUnitsPage && isMyRegistryPage}
-                  color={colors.leftNavTextColor}
-                  highlightColor={colors.leftNavHighlightColor}
                   to={`/units?orgUid=${myOrgUid}&myRegistry=true`}
                 >
                   <FormattedMessage id="my-units" />
                 </MenuItem>
 
                 <div></div>
-                <MenuItem
-                  selected={isFilesPage}
-                  color={colors.leftNavTextColor}
-                  highlightColor={colors.leftNavHighlightColor}
-                  to={`/files`}
-                >
+                <MenuItem selected={isFilesPage} to={`/files`}>
                   <FormattedMessage id="my-files" />
                 </MenuItem>
 
-                <MenuItem
-                  selected={isOrganizationPage}
-                  color={colors.leftNavTextColor}
-                  highlightColor={colors.leftNavHighlightColor}
-                  to="/organization"
-                >
+                <MenuItem selected={isOrganizationPage} to="/organization">
                   <FormattedMessage id="my-organization" />
                 </MenuItem>
                 {isGovernance && (
-                  <MenuItem
-                    selected={isGovernancePage}
-                    color={colors.leftNavTextColor}
-                    highlightColor={colors.leftNavHighlightColor}
-                    to="/governance"
-                  >
+                  <MenuItem selected={isGovernancePage} to="/governance">
                     <FormattedMessage id="governance" />
                   </MenuItem>
                 )}
@@ -277,8 +226,6 @@ const LeftNav = withTheme(({ children, theme }) => {
               <>
                 <MenuItem
                   to={projectsPageUrl}
-                  style={{ color: colors.leftNavTextColor }}
-                  highlightColor={colors.leftNavHighlightColor}
                   onClick={() => setConfirmCreateOrgIsVisible(true)}
                   disabled
                 >
@@ -287,8 +234,6 @@ const LeftNav = withTheme(({ children, theme }) => {
                 <div></div>
                 <MenuItem
                   to={projectsPageUrl}
-                  color={colors.leftNavTextColor}
-                  highlightColor={colors.leftNavHighlightColor}
                   onClick={() => setConfirmCreateOrgIsVisible(true)}
                   disabled
                 >

--- a/src/store/actions/app.js
+++ b/src/store/actions/app.js
@@ -4,7 +4,6 @@ import constants from '../../constants';
 import { keyMirror } from '../store-functions';
 import { LANGUAGE_CODES } from '../../translations';
 import { getOrganizationData } from './climateWarehouseActions';
-import theme from '../../theme';
 
 export const actions = keyMirror(
   'ACTIVATE_PROGRESS_INDICATOR',
@@ -62,7 +61,7 @@ export const setThemeFromLocalStorage = {
 export const setCustomTheme = customColors => {
   return {
     type: actions.SET_CUSTOM_THEME,
-    payload: { ...theme, customColors },
+    payload: customColors,
   };
 };
 

--- a/src/store/actions/app.js
+++ b/src/store/actions/app.js
@@ -4,12 +4,14 @@ import constants from '../../constants';
 import { keyMirror } from '../store-functions';
 import { LANGUAGE_CODES } from '../../translations';
 import { getOrganizationData } from './climateWarehouseActions';
+import theme from '../../theme';
 
 export const actions = keyMirror(
   'ACTIVATE_PROGRESS_INDICATOR',
   'DEACTIVATE_PROGRESS_INDICATOR',
   'TOGGLE_THEME',
   'SET_THEME',
+  'SET_CUSTOM_THEME',
   'SET_GLOBAL_ERROR_MESSAGE',
   'CLEAR_GLOBAL_ERROR_MESSAGE',
   'SET_LOCALE',
@@ -55,6 +57,13 @@ export const deactivateProgressIndicator = {
 export const setThemeFromLocalStorage = {
   type: actions.SET_THEME,
   payload: localStorage.getItem('theme'),
+};
+
+export const setCustomTheme = customColors => {
+  return {
+    type: actions.SET_CUSTOM_THEME,
+    payload: { ...theme, customColors },
+  };
 };
 
 export const toggleTheme = {

--- a/src/store/reducers/appReducer.js
+++ b/src/store/reducers/appReducer.js
@@ -74,7 +74,7 @@ const appReducer = (state = initialState, action) => {
       }
       return state;
     case appActions.SET_CUSTOM_THEME:
-      return { ...state, customTheme: action.payload };
+      return u({ customTheme: action.payload }, state);
     case appActions.TOGGLE_THEME:
       // eslint-disable-next-line
       const theme =

--- a/src/store/reducers/appReducer.js
+++ b/src/store/reducers/appReducer.js
@@ -3,11 +3,13 @@ import u from 'updeep';
 import { actions as appActions } from '../actions/app';
 import { actions as socketActions } from '../actions/socket';
 import constants from '../../constants';
+import theme from '../../theme';
 
 const initialState = {
   socketStatus: 'Waiting for status',
   showProgressOverlay: false,
   theme: constants.THEME.DEFAULT,
+  customTheme: theme,
   errorMessage: null,
   locale: null,
   connectionCheck: true,
@@ -71,7 +73,8 @@ const appReducer = (state = initialState, action) => {
         return u({ theme: action.payload }, state);
       }
       return state;
-
+    case appActions.SET_CUSTOM_THEME:
+      return { ...state, customTheme: action.payload };
     case appActions.TOGGLE_THEME:
       // eslint-disable-next-line
       const theme =

--- a/src/theme.js
+++ b/src/theme.js
@@ -41,6 +41,11 @@ const colors = {
     background: '#F0F2F5',
     onSurface: '#000000',
     onButton: '#FFFFFF',
+    leftNav: {
+      bg: 'rgb(240, 242, 245)',
+      text: '#6e7d7f',
+      highlight: '#fff',
+    },
     status: {
       info: {
         primary: '#91D5FF',


### PR DESCRIPTION
This PR adds support for receiving and applying theme changes broadcasted from the parent application, ensuring a consistent look and feel across the entire application suite.

### Changes
- Updated the child app to listen for theme change events from the parent app via window events.
- Implemented logic to dynamically update the app's theme based on changes broadcasted from the parent app.
